### PR TITLE
Add image zoom/lightbox for puzzle images

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -236,3 +236,31 @@ body {
 .animate-bar-fill {
   animation: bar-fill 0.5s ease-out backwards;
 }
+
+/* Image zoom modal — scale-up entrance */
+@keyframes zoom-modal-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-zoom-modal-enter {
+  animation: zoom-modal-enter 0.2s ease-out forwards;
+}
+
+/* Zoom hint toast — fade in, hold, fade out */
+@keyframes zoom-hint {
+  0% { opacity: 0; transform: translateY(0.5rem); }
+  15% { opacity: 1; transform: translateY(0); }
+  75% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(0); }
+}
+
+.animate-zoom-hint {
+  animation: zoom-hint 5s ease-out forwards;
+}

--- a/components/GamePage.tsx
+++ b/components/GamePage.tsx
@@ -226,7 +226,7 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
               onClick={() => { if (puzzle.image_url && Date.now() - zoomClosedAt.current > 300) { setZoomKey(k => k + 1); setShowZoom(true); } }}
               role="button"
               tabIndex={0}
-              onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && puzzle.image_url) { e.preventDefault(); setShowZoom(true); } }}
+              onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && puzzle.image_url) { e.preventDefault(); setZoomKey(k => k + 1); setShowZoom(true); } }}
               aria-label="Click to zoom image"
             >
               {puzzle.image_url ? (

--- a/components/GamePage.tsx
+++ b/components/GamePage.tsx
@@ -3,10 +3,12 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { ZoomIn } from 'lucide-react';
 import { Puzzle, Hint, Condition } from '@/lib/supabase';
 import GameClient from './GameClient';
 import StatsModal from './StatsModal';
 import FeedbackModal from './FeedbackModal';
+import ImageZoomModal from './ImageZoomModal';
 import { GameState, getStatistics, Statistics } from '@/lib/localStorage';
 
 interface GamePageProps {
@@ -21,6 +23,12 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [showStats, setShowStats] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
+  const [showZoom, setShowZoom] = useState(false);
+  const zoomClosedAt = useRef(0);
+  const handleZoomClose = useCallback(() => {
+    zoomClosedAt.current = Date.now();
+    setShowZoom(false);
+  }, []);
   const [stats, setStats] = useState<Statistics>({
     gamesPlayed: 0,
     gamesWon: 0,
@@ -85,6 +93,11 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
     ? puzzle.annotated_image_url
     : null;
   const showAnnotated = !!annotatedImageUrl && (gameState?.guesses.length ?? 0) >= 1;
+
+  // Active image URL for zoom modal — show whichever version is currently displayed
+  const activeImageUrl = showAnnotated && annotatedImageUrl
+    ? annotatedImageUrl
+    : puzzle.image_url;
 
   return (
     <div className="min-h-screen-safe relative overflow-y-auto overflow-x-hidden" style={{ minHeight: 'var(--full-vh)' }}>
@@ -207,7 +220,14 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
 
           {/* Medical Image Display - sticky on mobile so it stays visible when keyboard opens */}
           <div className="w-full max-w-3xl lg:max-w-4xl mb-3 sm:mb-6 sticky top-0 sm:static z-20 pb-2">
-            <div className={`relative w-full aspect-[16/9] bg-black rounded-lg overflow-hidden shadow-2xl transition-all duration-300 ${imageBorderStyle}${showImagePulse ? ' animate-image-pulse' : ''}`}>
+            <div
+              className={`relative w-full aspect-[16/9] bg-black rounded-lg overflow-hidden shadow-2xl transition-all duration-300 cursor-pointer ${imageBorderStyle}${showImagePulse ? ' animate-image-pulse' : ''}`}
+              onClick={() => puzzle.image_url && Date.now() - zoomClosedAt.current > 300 && setShowZoom(true)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && puzzle.image_url) { e.preventDefault(); setShowZoom(true); } }}
+              aria-label="Click to zoom image"
+            >
               {puzzle.image_url ? (
                 <Image
                   src={puzzle.image_url}
@@ -232,6 +252,12 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
                     className="object-contain"
                     sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 896px"
                   />
+                </div>
+              )}
+              {/* Zoom indicator icon */}
+              {puzzle.image_url && (
+                <div className="absolute bottom-3 right-3 bg-black/50 backdrop-blur-sm rounded-full p-1.5 text-white/80 pointer-events-none">
+                  <ZoomIn size={20} />
                 </div>
               )}
             </div>
@@ -323,6 +349,16 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
         onClose={() => setShowFeedback(false)}
         pageContext={isArchive ? `archive/day-${dayNumber}` : `day-${dayNumber}`}
       />
+
+      {/* Image Zoom Modal */}
+      {activeImageUrl && (
+        <ImageZoomModal
+          isOpen={showZoom}
+          onClose={handleZoomClose}
+          imageUrl={activeImageUrl}
+          altText={`Puzzle ${puzzle.puzzle_number}${showAnnotated ? ' annotated' : ''}`}
+        />
+      )}
     </div>
   );
 }

--- a/components/GamePage.tsx
+++ b/components/GamePage.tsx
@@ -24,6 +24,7 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
   const [showStats, setShowStats] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
   const [showZoom, setShowZoom] = useState(false);
+  const [zoomKey, setZoomKey] = useState(0);
   const zoomClosedAt = useRef(0);
   const handleZoomClose = useCallback(() => {
     zoomClosedAt.current = Date.now();
@@ -222,7 +223,7 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
           <div className="w-full max-w-3xl lg:max-w-4xl mb-3 sm:mb-6 sticky top-0 sm:static z-20 pb-2">
             <div
               className={`relative w-full aspect-[16/9] bg-black rounded-lg overflow-hidden shadow-2xl transition-all duration-300 cursor-pointer ${imageBorderStyle}${showImagePulse ? ' animate-image-pulse' : ''}`}
-              onClick={() => puzzle.image_url && Date.now() - zoomClosedAt.current > 300 && setShowZoom(true)}
+              onClick={() => { if (puzzle.image_url && Date.now() - zoomClosedAt.current > 300) { setZoomKey(k => k + 1); setShowZoom(true); } }}
               role="button"
               tabIndex={0}
               onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && puzzle.image_url) { e.preventDefault(); setShowZoom(true); } }}
@@ -350,10 +351,10 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
         pageContext={isArchive ? `archive/day-${dayNumber}` : `day-${dayNumber}`}
       />
 
-      {/* Image Zoom Modal */}
-      {activeImageUrl && (
+      {/* Image Zoom Modal — key forces fresh remount on each open */}
+      {showZoom && activeImageUrl && (
         <ImageZoomModal
-          isOpen={showZoom}
+          key={zoomKey}
           onClose={handleZoomClose}
           imageUrl={activeImageUrl}
           altText={`Puzzle ${puzzle.puzzle_number}${showAnnotated ? ' annotated' : ''}`}

--- a/components/ImageZoomModal.tsx
+++ b/components/ImageZoomModal.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import Image from 'next/image';
+import { X } from 'lucide-react';
+
+interface ImageZoomModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  imageUrl: string;
+  altText: string;
+}
+
+export default function ImageZoomModal({ isOpen, onClose, imageUrl, altText }: ImageZoomModalProps) {
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [hasTransition, setHasTransition] = useState(true);
+  const [showHint, setShowHint] = useState(false);
+
+  const dragStart = useRef({ x: 0, y: 0 });
+  const translateStart = useRef({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Pinch-to-zoom refs
+  const initialPinchDistance = useRef(0);
+  const scaleAtPinchStart = useRef(1);
+
+  // Interaction tracking — prevents close after zoom/pan/pinch gestures
+  const pointerDownPos = useRef({ x: 0, y: 0 });
+  const interactionCooldown = useRef(false);
+  const cooldownTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Drag-ready flags — set on pointer down, cleared on up, reset on modal open
+  const mouseDownReady = useRef(false);
+  const touchDownReady = useRef(false);
+
+  // Refs mirroring state for native event listeners (avoid stale closures)
+  const isDraggingRef = useRef(false);
+  const scaleRef = useRef(1);
+
+  // Set a cooldown that blocks close for a short period after zoom/pan activity
+  const startCooldown = useCallback(() => {
+    interactionCooldown.current = true;
+    clearTimeout(cooldownTimer.current);
+    cooldownTimer.current = setTimeout(() => {
+      interactionCooldown.current = false;
+    }, 300);
+  }, []);
+
+  // Keep refs in sync with state for native event listeners
+  useEffect(() => { isDraggingRef.current = isDragging; }, [isDragging]);
+  useEffect(() => { scaleRef.current = scale; }, [scale]);
+
+  // Reset state when modal opens + show hint
+  useEffect(() => {
+    if (isOpen) {
+      setScale(1);
+      setTranslate({ x: 0, y: 0 });
+      setIsDragging(false);
+      setHasTransition(true);
+      interactionCooldown.current = false;
+      mouseDownReady.current = false;
+      touchDownReady.current = false;
+      clearTimeout(cooldownTimer.current);
+
+      setShowHint(true);
+      const hideTimer = setTimeout(() => setShowHint(false), 5000);
+      return () => clearTimeout(hideTimer);
+    } else {
+      setShowHint(false);
+    }
+  }, [isOpen]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => clearTimeout(cooldownTimer.current);
+  }, []);
+
+  // Lock body scroll
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+      return () => { document.body.style.overflow = ''; };
+    }
+  }, [isOpen]);
+
+  // ESC to close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Desktop: wheel zoom — native listener for passive:false
+  useEffect(() => {
+    if (!isOpen) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      startCooldown();
+      setHasTransition(true);
+      setScale(prev => {
+        const delta = e.deltaY > 0 ? -0.15 : 0.15;
+        const newScale = Math.min(Math.max(prev + delta, 1), 4);
+        if (newScale <= 1) {
+          setTranslate({ x: 0, y: 0 });
+        }
+        return newScale;
+      });
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => container.removeEventListener('wheel', handleWheel);
+  }, [isOpen, startCooldown]);
+
+  // Mobile: touchmove — native listener for passive:false (preventDefault required)
+  useEffect(() => {
+    if (!isOpen) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleNativeTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+      if (e.touches.length === 2) {
+        // Pinch zoom
+        const dx = e.touches[0].clientX - e.touches[1].clientX;
+        const dy = e.touches[0].clientY - e.touches[1].clientY;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        const pinchScale = distance / initialPinchDistance.current;
+        const newScale = Math.min(Math.max(scaleAtPinchStart.current * pinchScale, 1), 4);
+        setScale(newScale);
+        startCooldown();
+        if (newScale <= 1) {
+          setTranslate({ x: 0, y: 0 });
+        }
+      } else if (e.touches.length === 1) {
+        // Start drag only once finger actually moves
+        if (touchDownReady.current && !isDraggingRef.current) {
+          const dx = e.touches[0].clientX - dragStart.current.x;
+          const dy = e.touches[0].clientY - dragStart.current.y;
+          if (Math.sqrt(dx * dx + dy * dy) >= 3) {
+            setIsDragging(true);
+            isDraggingRef.current = true;
+            setHasTransition(false);
+            startCooldown();
+          }
+          return;
+        }
+        if (!isDraggingRef.current) return;
+        const dx = e.touches[0].clientX - dragStart.current.x;
+        const dy = e.touches[0].clientY - dragStart.current.y;
+        setTranslate({
+          x: translateStart.current.x + dx / scaleRef.current,
+          y: translateStart.current.y + dy / scaleRef.current,
+        });
+      }
+    };
+
+    container.addEventListener('touchmove', handleNativeTouchMove, { passive: false });
+    return () => container.removeEventListener('touchmove', handleNativeTouchMove);
+  }, [isOpen, startCooldown]);
+
+  // --- Pointer down: record position for all interactions ---
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    pointerDownPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  // --- Pointer up: close only on clean tap (no drag, no zoom, no cooldown) ---
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    // Don't close during cooldown (just finished zooming/pinching)
+    if (interactionCooldown.current) return;
+    // Don't close if currently dragging
+    if (isDragging) return;
+    // Don't close if pointer moved significantly (was a drag)
+    const dx = e.clientX - pointerDownPos.current.x;
+    const dy = e.clientY - pointerDownPos.current.y;
+    if (Math.sqrt(dx * dx + dy * dy) >= 5) return;
+    // Clean tap — close the modal
+    onClose();
+  }, [isDragging, onClose]);
+
+  // --- Mouse handlers (desktop drag-to-pan) ---
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (scale <= 1) return;
+    e.preventDefault();
+    mouseDownReady.current = true;
+    dragStart.current = { x: e.clientX, y: e.clientY };
+    translateStart.current = { ...translate };
+  }, [scale, translate]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    // Start dragging only once mouse actually moves (not on click)
+    if (mouseDownReady.current && !isDragging) {
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+      if (Math.sqrt(dx * dx + dy * dy) >= 3) {
+        setIsDragging(true);
+        setHasTransition(false);
+        startCooldown();
+      }
+      return;
+    }
+    if (!isDragging) return;
+    const dx = e.clientX - dragStart.current.x;
+    const dy = e.clientY - dragStart.current.y;
+    setTranslate({
+      x: translateStart.current.x + dx / scale,
+      y: translateStart.current.y + dy / scale,
+    });
+  }, [isDragging, scale, startCooldown]);
+
+  const handleMouseUp = useCallback(() => {
+    mouseDownReady.current = false;
+    if (isDragging) {
+      setIsDragging(false);
+      setHasTransition(true);
+      startCooldown();
+    }
+  }, [isDragging, startCooldown]);
+
+  // --- Touch handlers (mobile drag + pinch-to-zoom) ---
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length === 2) {
+      // Pinch start
+      touchDownReady.current = false;
+      const dx = e.touches[0].clientX - e.touches[1].clientX;
+      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      initialPinchDistance.current = Math.sqrt(dx * dx + dy * dy);
+      scaleAtPinchStart.current = scale;
+      setHasTransition(false);
+      startCooldown();
+    } else if (e.touches.length === 1 && scale > 1) {
+      // Ready to drag — but don't start until actual movement
+      touchDownReady.current = true;
+      dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+      translateStart.current = { ...translate };
+    }
+  }, [scale, translate, startCooldown]);
+
+  const handleTouchEnd = useCallback(() => {
+    touchDownReady.current = false;
+    if (isDragging) {
+      setIsDragging(false);
+      isDraggingRef.current = false;
+      setHasTransition(true);
+      startCooldown();
+    }
+    initialPinchDistance.current = 0;
+  }, [isDragging, startCooldown]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-[100] animate-backdrop-fade"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Zoomed image view"
+    >
+      {/* Close button */}
+      <button
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        className="absolute top-4 right-4 z-[101] w-10 h-10 flex items-center justify-center rounded-full bg-black/50 backdrop-blur-sm text-white/80 hover:text-white hover:bg-black/70 transition-colors"
+        aria-label="Close"
+      >
+        <X size={22} />
+      </button>
+
+      {/* Zoomable image container — fills entire modal */}
+      <div
+        ref={containerRef}
+        className="w-full h-full flex items-center justify-center p-4 sm:p-8"
+        style={{ touchAction: 'none' }}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Entrance animation wrapper — separate from zoom transform
+            so CSS animation doesn't override inline transform */}
+        <div className="relative w-full h-full max-w-6xl animate-zoom-modal-enter">
+          {/* Zoom/pan transform div */}
+          <div
+            className={`relative w-full h-full ${
+              scale > 1
+                ? isDragging ? 'cursor-grabbing' : 'cursor-grab'
+                : 'cursor-default'
+            }`}
+            style={{
+              transform: `scale(${scale}) translate(${translate.x}px, ${translate.y}px)`,
+              willChange: 'transform',
+              transition: hasTransition ? 'transform 0.15s ease-out' : 'none',
+            }}
+          >
+            <Image
+              src={imageUrl}
+              alt={altText}
+              fill
+              className="object-contain"
+              sizes="100vw"
+              priority
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Usage hint — shows briefly on first few opens */}
+      {showHint && (
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-[101] pointer-events-none animate-zoom-hint">
+          <div className="bg-black/60 backdrop-blur-sm text-white/80 text-xs px-4 py-2 rounded-full whitespace-nowrap">
+            <span className="hidden sm:inline">Scroll to zoom &middot; Drag to pan</span>
+            <span className="sm:hidden">Pinch to zoom &middot; Drag to pan</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a fullscreen lightbox modal for inspecting radiological puzzle images up close
- **Desktop**: scroll-to-zoom (1x–4x), click-drag to pan, click backdrop/X/ESC to close
- **Mobile**: pinch-to-zoom, single-finger drag to pan, tap outside/X to close
- Magnifying glass icon on image corner indicates zoom capability
- Auto-dismissing hint toast (5s) shows zoom/pan instructions on each open
- Works with both annotated and non-annotated images, current and archived puzzles
- Zero new dependencies — built with CSS transforms + native event handlers
- Zero localStorage impact — no interference with game state, stats, or streaks

## Files changed
- **`components/ImageZoomModal.tsx`** (new) — Self-contained lightbox component
- **`components/GamePage.tsx`** — Zoom trigger, state, and modal integration
- **`app/globals.css`** — Two CSS animations (modal entrance + hint toast)

## Test plan
- [x] All 159 existing tests pass
- [ ] Desktop: click image → zoom modal opens, scroll to zoom, drag to pan, close via X/ESC/backdrop
- [ ] Mobile: tap image → fullscreen modal, pinch to zoom, drag to pan, tap X/outside to close
- [ ] Annotated image: make a guess, verify zoom shows annotated version
- [ ] Archive puzzle: navigate to archived puzzle, verify zoom works identically
- [ ] No regression: play full game, verify stats/streaks/share unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)