### PR TITLE
Fix excessive serverless function invocations on Vercel

### DIFF
--- a/app/archive/[day]/page.tsx
+++ b/app/archive/[day]/page.tsx
@@ -1,4 +1,8 @@
 import { redirect } from 'next/navigation';
+
+// Cache archive pages for 1 hour - puzzle data doesn't change for past days
+export const revalidate = 3600;
+
 import { getPuzzleForDay, getHintsFromPuzzle, getAllConditions } from '@/lib/supabase';
 import { getDayNumber } from '@/lib/gameLogic';
 import GamePage from '@/components/GamePage';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,8 @@ import { getTodaysPuzzle, getHintsFromPuzzle, getAllConditions } from '@/lib/sup
 import { getDayNumber } from '@/lib/gameLogic';
 import GamePage from '@/components/GamePage';
 
-// Disable caching - puzzle changes daily at midnight EST
-export const dynamic = 'force-dynamic';
+// Revalidate every 60 seconds - puzzle changes daily at midnight EST
+export const revalidate = 60;
 
 export default async function Home() {
   let dayNumber: number;

--- a/components/ArchiveBrowser.tsx
+++ b/components/ArchiveBrowser.tsx
@@ -44,6 +44,7 @@ export default function ArchiveBrowser() {
             <Link
               key={day.dayNumber}
               href={isToday ? '/' : `/archive/${day.dayNumber}`}
+              prefetch={false}
               className={`relative flex flex-col items-center justify-center rounded-lg p-2.5 sm:p-3 transition-all duration-150 ${
                 isWon
                   ? 'bg-success/80 hover:bg-success ring-1 ring-success/50'


### PR DESCRIPTION
## Summary
- **Disable prefetch on archive links** — each archive page visit was triggering ~87 serverless function calls (one per day link). In production logs, 57% of all requests were archive day prefetches, all cache misses hitting serverless functions.
- **Add ISR caching to archive day pages** — `revalidate = 3600` (1 hour). Past puzzle data never changes, so subsequent requests serve from edge cache.
- **Switch homepage from `force-dynamic` to ISR** — `revalidate = 60` (1 minute). Puzzle changes once per day at midnight EST, so 60s caching is safe. Eliminates redundant SSR for bots, repeat visitors, and concurrent users.

## Impact
| Change | Estimated reduction |
|--------|-------------------|
| Archive `prefetch={false}` | ~87x fewer function calls per archive visit |
| Archive ISR (1hr) | Repeated visits to same day serve from cache |
| Homepage ISR (60s) | ~60x fewer function calls during peak traffic |

## Test plan
- [x] All 159 unit/integration tests pass
- [x] Production build succeeds — homepage shows `Revalidate: 1m` in build output
- [ ] Verify archive page no longer prefetches day links in Network tab
- [ ] Monitor Vercel function invocation count after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)