### PR TITLE
Chunk 01: Design tokens & fonts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,6 +18,17 @@
   --color-page-bg-dark: #0f172a;
   --color-modal-bg: #1e3a5f;
   --color-footer-bg: #1a2744;
+
+  /* Softer image-border "ring" colors (result feedback on the X-ray card) */
+  --color-ring-success: #5a9d86;
+  --color-ring-warning: #e6c84f;
+  --color-ring-error: #c4736b;
+
+  /* Glass surface tokens — shared by navbar, modals, and glass primitives */
+  --glass-bg: rgba(255, 255, 255, 0.06);
+  --glass-blur: blur(22px) saturate(160%);
+  --glass-border: 1px solid rgba(255, 255, 255, 0.14);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
 @theme inline {
@@ -36,8 +47,11 @@
   --color-page-bg-dark: var(--color-page-bg-dark);
   --color-modal-bg: var(--color-modal-bg);
   --color-footer-bg: var(--color-footer-bg);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --color-ring-success: var(--color-ring-success);
+  --color-ring-warning: var(--color-ring-warning);
+  --color-ring-error: var(--color-ring-error);
+  --font-sans: var(--font-inter);
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --font-baloo-2: var(--font-baloo-2);
 }
 
@@ -91,7 +105,20 @@ html {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), Arial, Helvetica, sans-serif;
+}
+
+/* Slim glass scrollbars (design foundation) */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 /* Mobile viewport height handling for keyboard */
@@ -263,4 +290,40 @@ body {
 
 .animate-zoom-hint {
   animation: zoom-hint 5s ease-out forwards;
+}
+
+/* =========================================================
+   Redesign keyframes (design foundation — used by later chunks:
+   toasts, modals, hint reveal, animated background)
+   ========================================================= */
+@keyframes toastIn {
+  from { opacity: 0; transform: translate(-50%, -10px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes modalEnter {
+  from { opacity: 0; transform: scale(0.95) translateY(10px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+@keyframes hintReveal {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes bgDriftA {
+  from { transform: translate3d(0, 0, 0) scale(1); }
+  to { transform: translate3d(5%, 4%, 0) scale(1.12); }
+}
+@keyframes bgDriftB {
+  from { transform: translate3d(0, 0, 0) scale(1.05); }
+  to { transform: translate3d(-4%, -3%, 0) scale(0.96); }
+}
+
+/* Respect reduced-motion for the ambient background drift */
+@media (prefers-reduced-motion: reduce) {
+  [style*="bgDrift"] {
+    animation: none !important;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,23 +1,23 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Baloo_2 } from "next/font/google";
+import { Inter, Baloo_2 } from "next/font/google";
 import "./globals.css";
 import CookieConsent from "@/components/CookieConsent";
 import StatsRecoveryProvider from "@/components/StatsRecoveryProvider";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+// Body font (design system)
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
+// Display font — headings, wordmark, buttons
 const baloo2 = Baloo_2({
   variable: "--font-baloo-2",
   subsets: ["latin"],
-  weight: ["800"],
+  weight: ["400", "500", "600", "700", "800"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -189,7 +189,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${baloo2.variable} antialiased`}
+        className={`${inter.variable} ${baloo2.variable} antialiased`}
         suppressHydrationWarning
       >
         {children}

--- a/components/GameClient.tsx
+++ b/components/GameClient.tsx
@@ -326,7 +326,7 @@ export default function GameClient({
         ) : (
           <>
             <div className="mb-3 text-white/80 text-center drop-shadow-[0_4px_12px_rgba(0,0,0,0.9)]">
-              <p className="text-lg tracking-wide font-baloo-2">
+              <p className="text-lg tracking-wide font-baloo-2 font-semibold">
                 Guess {gameState.guesses.length + 1} / {MAX_GUESSES}
               </p>
             </div>
@@ -367,7 +367,7 @@ export default function GameClient({
           <>
             {/* Guesses counter - in flow */}
             <div className="mb-3 text-white/80 text-center drop-shadow-[0_4px_12px_rgba(0,0,0,0.9)]">
-              <p className="text-lg tracking-wide font-baloo-2">
+              <p className="text-lg tracking-wide font-baloo-2 font-semibold">
                 Guess {gameState.guesses.length + 1} / {MAX_GUESSES}
               </p>
             </div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Throwaway redesign prototype — reference only, never shipped.
+    "design-reference/**",
   ]),
 ]);
 


### PR DESCRIPTION
Foundation chunk of the iterative UI redesign. **Targets `feature/ui-redesign`, not `main` — the live site is unaffected.** Presentation-only; no data flow, storage, or game logic touched.

## What's in this chunk (per `design-reference/REDESIGN_PLAN.md` → 01)
Port the design's `C` / `GLASS` tokens, Baloo 2 / Inter fonts, and keyframes into `globals.css` + `layout.tsx`.

### Fonts (`app/layout.tsx`)
- Swap **Geist → Inter** as the body font (body previously fell back to Arial, so Geist was dead weight).
- Expand **Baloo 2** to weights **400–800** (was 800 only); add `display: swap`.

### Tokens & styles (`app/globals.css`)
- Body/`--font-sans` → Inter.
- Add softer image-border **ring colors** (`--color-ring-success/warning/error`) + Tailwind theme tokens.
- Add **glass tokens** (`--glass-bg/-blur/-border/-shadow`) for later navbar/modal/glass-primitive chunks.
- Add slim **glass scrollbars**.
- Append design **keyframes** (`toastIn`, `fadeIn`, `modalEnter`, `hintReveal`, `bgDriftA/B`) + reduced-motion guard — **additive**, existing `animate-*` animations untouched.

### Guess counter (`components/GameClient.tsx`)
- Render "Guess N / 5" in **real Baloo 2 semibold**. It carried `font-baloo-2` but at weight 400 with no light Baloo loaded, so it silently fell back to sans; expanding the weight range surfaced real Baloo.

### Tooling (`eslint.config.mjs`)
- Ignore the throwaway `design-reference/` prototype, which was **pre-existingly** breaking `pnpm lint` (50 errors → **0**). Unblocks the "keep green" gate for every subsequent chunk.

## Verification
- ✅ Lint: **0 errors** (4 pre-existing test-file warnings)
- ✅ Tests: **159/159** passing
- ✅ Desktop + mobile render cleanly; no console/server errors
- ✅ User data untouched (CSS/font/config + one className)

🤖 Generated with [Claude Code](https://claude.com/claude-code)