### PR TITLE
Chunks 03–08: glass primitives, navbar, X-ray card, hints, guess bar, toasts

### DIFF
--- a/__tests__/component/DiagnosisAutocomplete.test.tsx
+++ b/__tests__/component/DiagnosisAutocomplete.test.tsx
@@ -90,7 +90,7 @@ describe('DiagnosisAutocomplete', () => {
 
       // First item selected (Pneumonia or Pneumothorax)
       const buttons = screen.getAllByRole('button', { name: /Pneum/ })
-      expect(buttons[0]).toHaveClass('bg-blue-100')
+      expect(buttons[0]).toHaveClass('bg-white/10')
     })
 
     it('escape closes dropdown', async () => {
@@ -134,7 +134,7 @@ describe('DiagnosisAutocomplete', () => {
       // Should skip Pneumothorax and select Pneumonia
       const buttons = screen.getAllByRole('button', { name: /Pneum/ })
       const nonDisabledSelected = buttons.find(
-        btn => btn.classList.contains('bg-blue-100') && !btn.hasAttribute('disabled')
+        btn => btn.classList.contains('bg-white/10') && !btn.hasAttribute('disabled')
       )
       expect(nonDisabledSelected).toBeDefined()
     })

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,7 +26,10 @@
 
   /* Glass surface tokens — shared by navbar, modals, and glass primitives */
   --glass-bg: rgba(255, 255, 255, 0.06);
-  --glass-blur: blur(22px) saturate(160%);
+  /* Blur radius kept modest: backdrop-filter re-samples every scroll frame, and
+     cost scales with radius. 14px still reads as glass but is much cheaper than
+     the original 22px, which noticeably smooths scrolling. */
+  --glass-blur: blur(14px) saturate(140%);
   --glass-border: 1px solid rgba(255, 255, 255, 0.14);
   --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }

--- a/components/DiagnosisAutocomplete.tsx
+++ b/components/DiagnosisAutocomplete.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Send } from 'lucide-react';
 import { Condition } from '@/lib/supabase';
 
 interface DiagnosisAutocompleteProps {
@@ -10,7 +11,33 @@ interface DiagnosisAutocompleteProps {
   previousGuesses?: string[];
   isMobile?: boolean;
   disabled?: boolean;
+  /** When provided, shows the "Guess N / total" label inside the input pill. */
+  current?: number;
+  total?: number;
 }
+
+// Amber Submit gradient — shares the AccentButton token wiring.
+const ACCENT_STYLE = {
+  background: 'linear-gradient(to bottom, var(--color-accent-light), var(--color-accent))',
+  boxShadow: '0 4px 14px rgba(245, 158, 11, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.4)',
+};
+
+// Input pill — a themed off-white field (cool white that sits in the navy
+// theme). Kept near-opaque with no backdrop-filter: it reads as a clean light
+// bar either way, and dropping the live blur makes the fixed mobile bar much
+// cheaper to scroll past. The border color is driven by the error state.
+const PILL_STYLE = {
+  background: 'linear-gradient(to bottom, rgba(255, 255, 255, 0.97), rgba(231, 237, 248, 0.95))',
+  boxShadow: '0 8px 24px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.7)',
+};
+
+// Dark glass dropdown panel.
+const DROPDOWN_STYLE = {
+  background: 'rgba(17, 27, 52, 0.92)',
+  backdropFilter: 'var(--glass-blur)',
+  WebkitBackdropFilter: 'var(--glass-blur)',
+  border: '1px solid rgba(255, 255, 255, 0.14)',
+};
 
 export default function DiagnosisAutocomplete({
   conditions,
@@ -18,7 +45,9 @@ export default function DiagnosisAutocomplete({
   onDropdownStateChange,
   previousGuesses = [],
   isMobile = false,
-  disabled = false
+  disabled = false,
+  current,
+  total,
 }: DiagnosisAutocompleteProps) {
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
@@ -212,10 +241,79 @@ export default function DiagnosisAutocomplete({
     setValidationError(null);
   };
 
+  const showLabel = current != null && total != null;
+
   return (
-    <div ref={containerRef} className="w-full max-w-xl mx-auto relative z-50">
-      <div className="flex gap-2 sm:gap-3">
-        <div className="flex-1 relative">
+    <div ref={containerRef} className="w-full max-w-2xl mx-auto relative z-50">
+      {/* Positioning context: dropdown anchors to the pill only, not the error row */}
+      <div className="relative">
+        {/* Dropdown menu — appears above on mobile, below on desktop */}
+        {isOpen && filteredConditions.length > 0 && (
+          <div
+            className={`absolute left-0 right-0 z-50 overflow-hidden rounded-2xl shadow-2xl ${
+              isMobile ? 'bottom-full mb-2.5' : 'top-full mt-2.5'
+            }`}
+            style={DROPDOWN_STYLE}
+          >
+            <div
+              ref={dropdownRef}
+              className="overflow-y-auto"
+              style={{ maxHeight: isMobile ? 220 : 256 }}
+            >
+              {filteredConditions.map((condition, index) => {
+                const isDisabled = isPreviouslyGuessed(condition.name);
+
+                return (
+                  <button
+                    key={condition.id}
+                    onClick={() => handleSelectOption(condition.name)}
+                    disabled={isDisabled}
+                    className={`w-full text-left font-baloo-2 transition-colors border-b border-white/[0.06] last:border-b-0 ${
+                      isMobile ? 'px-[18px] py-[11px] text-[15px]' : 'px-5 py-3 text-base'
+                    } ${
+                      isDisabled ? 'cursor-not-allowed' : 'hover:bg-white/5'
+                    } ${index === selectedIndex && !isDisabled ? 'bg-white/10' : ''}`}
+                  >
+                    <div className={`font-medium ${isDisabled ? 'text-white/30' : 'text-white/90'}`}>
+                      {condition.name}
+                      {isDisabled && (
+                        <span className="ml-2 text-xs opacity-70">(Previously selected)</span>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Result count indicator */}
+            {filteredConditions.length === 40 && (
+              <div className="px-4 py-2 text-center text-xs text-white/45 font-baloo-2 border-t border-white/10 bg-black/20">
+                Showing first 40 results. Type more to narrow down.
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Glass input pill: label · divider · input · Submit */}
+        <div
+          className={`flex items-center w-full rounded-2xl border ${
+            validationError ? 'border-[rgba(196,115,107,0.85)]' : 'border-[rgba(148,163,190,0.45)]'
+          } ${isMobile ? 'gap-2.5 pl-3.5 pr-[7px] py-[7px]' : 'gap-3.5 pl-[18px] pr-2 py-2'}`}
+          style={PILL_STYLE}
+        >
+          {showLabel && (
+            <>
+              <p className="font-mono uppercase select-none flex-shrink-0 font-semibold tracking-[0.12em] text-slate-500 text-[11px] sm:text-xs">
+                Guess {current} / {total}
+              </p>
+              <span
+                className="flex-shrink-0 w-px bg-slate-400/40"
+                style={{ height: isMobile ? 22 : 26 }}
+                aria-hidden="true"
+              />
+            </>
+          )}
+
           <input
             ref={inputRef}
             type="text"
@@ -223,77 +321,27 @@ export default function DiagnosisAutocomplete({
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             disabled={disabled}
-            placeholder={disabled ? "Accept notice to play" : "Diagnosis..."}
+            placeholder={disabled ? 'Accept notice to play' : 'Diagnosis...'}
             aria-invalid={!!validationError}
-            aria-describedby={validationError ? "diagnosis-error" : undefined}
-            className={`w-full px-3 sm:px-6 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-baloo-2 bg-white bg-opacity-90 text-gray-800 placeholder-gray-500 focus:outline-none focus:ring-2 ${
-              validationError
-                ? 'ring-2 ring-red-500 focus:ring-red-500'
-                : 'focus:ring-yellow-400'
+            aria-describedby={validationError ? 'diagnosis-error' : undefined}
+            className={`flex-1 min-w-0 bg-transparent outline-none font-baloo-2 font-medium text-slate-800 placeholder-slate-400 ${
+              isMobile ? 'text-base' : 'text-lg'
             }`}
             autoComplete="off"
           />
 
-          {/* Dropdown menu - appears above on mobile, below on desktop */}
-          {isOpen && filteredConditions.length > 0 && (
-            <div
-              className={`absolute left-0 right-0 bg-white rounded-lg shadow-2xl border border-gray-200 z-50 overflow-hidden ${
-                isMobile ? 'bottom-full mb-2' : 'top-full mt-2'
-              }`}
-            >
-              <div
-                ref={dropdownRef}
-                className="overflow-y-auto"
-                style={{ maxHeight: '180px' }}
-              >
-                {filteredConditions.map((condition, index) => {
-                  const isDisabled = isPreviouslyGuessed(condition.name);
-
-                  return (
-                    <button
-                      key={condition.id}
-                      onClick={() => handleSelectOption(condition.name)}
-                      disabled={isDisabled}
-                      className={`w-full text-left px-6 py-3 transition-colors border-b border-gray-100 last:border-b-0 ${
-                        isDisabled
-                          ? 'cursor-not-allowed bg-gray-50'
-                          : 'hover:bg-blue-50'
-                      } ${
-                        index === selectedIndex && !isDisabled ? 'bg-blue-100' : ''
-                      }`}
-                    >
-                      <div className={`font-medium ${isDisabled ? 'text-gray-400' : 'text-gray-800'}`}>
-                        {condition.name}
-                        {isDisabled && (
-                          <span className="ml-2 text-xs">(Previously selected)</span>
-                        )}
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-
-              {/* Result count indicator */}
-              {filteredConditions.length === 40 && (
-                <div className="px-6 py-2 bg-gray-50 text-xs text-gray-500 text-center border-t border-gray-200">
-                  Showing first 40 results. Type more to narrow down.
-                </div>
-              )}
-            </div>
-          )}
+          <button
+            onClick={handleSubmit}
+            disabled={disabled}
+            className={`flex items-center gap-2 font-baloo-2 font-bold flex-shrink-0 rounded-xl transition-transform active:scale-95 ${
+              isMobile ? 'px-4 py-[9px] text-[15px]' : 'px-[22px] py-[11px] text-[17px]'
+            } ${disabled ? 'bg-gray-500 text-gray-300 cursor-not-allowed' : 'text-black'}`}
+            style={disabled ? undefined : ACCENT_STYLE}
+          >
+            Submit
+            <Send size={isMobile ? 16 : 18} />
+          </button>
         </div>
-
-        <button
-          onClick={handleSubmit}
-          disabled={disabled}
-          className={`px-4 sm:px-8 py-3 sm:py-4 font-bold font-baloo-2 text-base sm:text-lg rounded-lg transition-all shadow-lg ${
-            disabled
-              ? 'bg-gray-500 text-gray-300 cursor-not-allowed'
-              : 'bg-gradient-to-r from-accent to-accent-light hover:from-accent hover:to-accent text-black'
-          }`}
-        >
-          Submit
-        </button>
       </div>
 
       {/* Validation error message */}
@@ -301,7 +349,7 @@ export default function DiagnosisAutocomplete({
         <div
           id="diagnosis-error"
           role="alert"
-          className="mt-2 px-3 py-2 bg-red-100 border border-red-300 rounded-lg text-red-700 text-sm font-medium flex items-center gap-2"
+          className="mt-2 px-3 py-2 rounded-lg text-[13px] font-baloo-2 flex items-center gap-2 text-[#ffd9d4] border border-[rgba(196,115,107,0.45)] bg-[rgba(196,115,107,0.18)]"
         >
           <svg
             className="w-4 h-4 flex-shrink-0"

--- a/components/GameClient.tsx
+++ b/components/GameClient.tsx
@@ -324,20 +324,15 @@ export default function GameClient({
             </button>
           </div>
         ) : (
-          <>
-            <div className="mb-3 text-white/80 text-center drop-shadow-[0_4px_12px_rgba(0,0,0,0.9)]">
-              <p className="text-lg tracking-wide font-baloo-2 font-semibold">
-                Guess {gameState.guesses.length + 1} / {MAX_GUESSES}
-              </p>
-            </div>
-            <DiagnosisAutocomplete
-              conditions={conditions}
-              onSubmit={handleSubmit}
-              onDropdownStateChange={handleDropdownStateChange}
-              previousGuesses={gameState.guesses}
-              disabled={!consentGiven}
-            />
-          </>
+          <DiagnosisAutocomplete
+            conditions={conditions}
+            onSubmit={handleSubmit}
+            onDropdownStateChange={handleDropdownStateChange}
+            previousGuesses={gameState.guesses}
+            disabled={!consentGiven}
+            current={gameState.guesses.length + 1}
+            total={MAX_GUESSES}
+          />
         )}
       </div>
 
@@ -365,13 +360,8 @@ export default function GameClient({
           </div>
         ) : (
           <>
-            {/* Guesses counter - in flow */}
-            <div className="mb-3 text-white/80 text-center drop-shadow-[0_4px_12px_rgba(0,0,0,0.9)]">
-              <p className="text-lg tracking-wide font-baloo-2 font-semibold">
-                Guess {gameState.guesses.length + 1} / {MAX_GUESSES}
-              </p>
-            </div>
-            {/* Input sticky at bottom on mobile - positions directly above keyboard */}
+            {/* Input sticky at bottom on mobile - positions directly above keyboard.
+                The "Guess N / 5" label now lives inside the input pill. */}
             <div className="fixed bottom-0 left-0 right-0 px-4 pb-[env(safe-area-inset-bottom,0px)] bg-gradient-to-t from-page-bg-dark via-page-bg-dark/80 to-transparent pt-4 z-40">
               <DiagnosisAutocomplete
                 conditions={conditions}
@@ -380,6 +370,8 @@ export default function GameClient({
                 previousGuesses={gameState.guesses}
                 isMobile={true}
                 disabled={!consentGiven}
+                current={gameState.guesses.length + 1}
+                total={MAX_GUESSES}
               />
             </div>
             {/* Spacer to prevent content from being hidden behind fixed input */}

--- a/components/GamePage.tsx
+++ b/components/GamePage.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 import { ZoomIn } from 'lucide-react';
 import { Puzzle, Hint, Condition } from '@/lib/supabase';
 import GameClient from './GameClient';
 import PageBackground from './PageBackground';
+import TopBar from './TopBar';
 import StatsModal from './StatsModal';
 import FeedbackModal from './FeedbackModal';
 import ImageZoomModal from './ImageZoomModal';
@@ -81,13 +81,17 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
   // Determine image border color based on first guess result
   // The first guess is made with only the image, so it reflects how helpful the image was
   const firstGuessResult = gameState?.guessResults[0];
-  let imageBorderStyle = '';
+  // Result-colored border on the X-ray card (design: XrayCard). A subtle neutral
+  // border shows before the first guess, then transitions to the softer
+  // success/warning/error ring color. Border-color only — a static paint with no
+  // glow filter — so the feedback stays cheap.
+  let imageBorderColor = 'border-white/[0.12]';
   if (firstGuessResult === 'correct') {
-    imageBorderStyle = 'ring-4 ring-success shadow-[0_0_20px_rgba(64,119,99,0.6)]';
+    imageBorderColor = 'border-ring-success';
   } else if (firstGuessResult === 'partial') {
-    imageBorderStyle = 'ring-4 ring-warning shadow-[0_0_20px_rgba(246,214,86,0.6)]';
+    imageBorderColor = 'border-ring-warning';
   } else if (firstGuessResult === 'incorrect') {
-    imageBorderStyle = 'ring-4 ring-error shadow-[0_0_20px_rgba(158,74,74,0.6)]';
+    imageBorderColor = 'border-ring-error';
   }
 
   // Annotated image: show after first guess if a valid URL is provided
@@ -108,85 +112,11 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
 
       {/* Content */}
       <div className="relative z-10 min-h-screen-safe flex flex-col" style={{ minHeight: 'var(--full-vh)' }}>
-        {/* Header with Logo and Buttons */}
-        <div className="flex flex-col sm:flex-row sm:items-center p-3 sm:px-6 sm:py-4 gap-0 sm:gap-0">
-          {/* Top row on mobile: Archives and Stats buttons */}
-          <div className="flex justify-between items-center sm:contents">
-            {/* Archives Button - Left side container with fixed width on desktop */}
-            <div className="sm:flex-1 sm:flex sm:justify-start">
-              <Link
-                href="/archive"
-                className="flex items-center gap-1 sm:gap-2 px-2.5 sm:px-4 py-1.5 sm:py-2 min-h-[36px] sm:min-h-[40px] bg-surface hover:bg-surface-hover text-white rounded-lg transition-colors"
-              >
-                <span className="text-base sm:text-xl">📁</span>
-                <span className="font-bold font-baloo-2 text-xs sm:text-base">Archives</span>
-              </Link>
-            </div>
-
-            {/* Logo and Title - Hidden on mobile, shown inline on larger screens */}
-            <div className="hidden sm:flex items-center gap-1 drop-shadow-[0_6px_20px_rgba(0,0,0,0.6)]">
-              <div className="relative w-16 h-16">
-                <Image
-                  src="/radle_icon.svg"
-                  alt="Radiordle Icon"
-                  width={64}
-                  height={64}
-                  className="object-contain"
-                />
-              </div>
-              <h1 className="text-4xl md:text-[3.375rem] text-white font-baloo-2 font-extrabold tracking-tight">
-                Radiordle
-              </h1>
-            </div>
-
-            {/* Stats and Feedback Buttons - Right side container with fixed width on desktop */}
-            <div className="sm:flex-1 sm:flex sm:justify-end">
-              <div className="flex items-center gap-1 sm:gap-2">
-                <Link
-                  href="/about"
-                  className="flex items-center gap-1 sm:gap-2 px-2.5 sm:px-4 py-1.5 sm:py-2 min-h-[36px] sm:min-h-[40px] bg-surface hover:bg-surface-hover text-white rounded-lg transition-colors"
-                  title="Learn More"
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4 sm:w-5 sm:h-5">
-                    <path fillRule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 01.67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 11-.671-1.34l.041-.022zM12 9a.75.75 0 100-1.5.75.75 0 000 1.5z" clipRule="evenodd" />
-                  </svg>
-                  <span className="hidden sm:inline font-bold font-baloo-2 text-xs sm:text-base">About</span>
-                </Link>
-                <button
-                  onClick={() => setShowFeedback(true)}
-                  className="flex items-center gap-1 sm:gap-2 px-2.5 sm:px-4 py-1.5 sm:py-2 min-h-[36px] sm:min-h-[40px] bg-surface hover:bg-surface-hover text-white rounded-lg transition-colors"
-                  title="Send Feedback"
-                >
-                  <span className="text-base sm:text-xl">💬</span>
-                  <span className="hidden sm:inline font-bold font-baloo-2 text-xs sm:text-base">Feedback</span>
-                </button>
-                <button
-                  onClick={() => setShowStats(true)}
-                  className="flex items-center gap-1 sm:gap-2 px-2.5 sm:px-4 py-1.5 sm:py-2 min-h-[36px] sm:min-h-[40px] bg-surface hover:bg-surface-hover text-white rounded-lg transition-colors"
-                >
-                  <span className="text-base sm:text-xl">📊</span>
-                  <span className="font-bold font-baloo-2 text-xs sm:text-base">Stats</span>
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Logo and Title - Second row on mobile only */}
-          <div className="flex sm:hidden items-center justify-center gap-1.5 drop-shadow-[0_6px_20px_rgba(0,0,0,0.6)] mt-0.5 -mb-0.5">
-            <div className="relative w-14 h-14">
-              <Image
-                src="/radle_icon.svg"
-                alt="Radiordle Icon"
-                width={56}
-                height={56}
-                className="object-contain"
-              />
-            </div>
-            <h1 className="text-[2.5rem] text-white font-baloo-2 font-extrabold tracking-tight">
-              Radiordle
-            </h1>
-          </div>
-        </div>
+        {/* Glass top navigation bar */}
+        <TopBar
+          onStats={() => setShowStats(true)}
+          onFeedback={() => setShowFeedback(true)}
+        />
 
         {/* Main Content */}
         <div className="flex-1 flex flex-col items-center justify-start sm:justify-start px-4 pt-2 pb-4 sm:pb-4 sm:pt-4">
@@ -194,7 +124,7 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
           {/* Medical Image Display - sticky on mobile so it stays visible when keyboard opens */}
           <div className="w-full max-w-3xl lg:max-w-4xl mb-3 sm:mb-6 sticky top-0 sm:static z-20 pb-2">
             <div
-              className={`relative w-full aspect-[16/9] bg-black rounded-lg overflow-hidden shadow-2xl transition-all duration-300 cursor-pointer ${imageBorderStyle}${showImagePulse ? ' animate-image-pulse' : ''}`}
+              className={`relative w-full aspect-[16/9] bg-black rounded-lg overflow-hidden border-2 ${imageBorderColor} shadow-[0_10px_34px_rgba(0,0,0,0.5)] transition-colors duration-300 cursor-pointer${showImagePulse ? ' animate-image-pulse' : ''}`}
               onClick={() => { if (puzzle.image_url && Date.now() - zoomClosedAt.current > 300) { setZoomKey(k => k + 1); setShowZoom(true); } }}
               role="button"
               tabIndex={0}
@@ -229,7 +159,7 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
               )}
               {/* Zoom indicator icon */}
               {puzzle.image_url && (
-                <div className="absolute bottom-3 right-3 bg-black/50 backdrop-blur-sm rounded-full p-1.5 text-white/80 pointer-events-none">
+                <div className="absolute bottom-3 right-3 bg-black/50 rounded-full p-1.5 text-white/80 pointer-events-none">
                   <ZoomIn size={20} />
                 </div>
               )}
@@ -278,7 +208,7 @@ export default function GamePage({ puzzle, hints, conditions, dayNumber, isArchi
                 return (
                   <div
                     key={hint.id}
-                    className={`relative ${hintStyle} ${textColor} rounded-xl px-5 py-3.5 transition-all duration-300 border border-white/10 shadow-md${isNewHint ? ' animate-hint-reveal' : ''}`}
+                    className={`relative ${hintStyle} ${textColor} rounded-xl px-5 py-3.5 transition-colors duration-300 border border-white/10 shadow-md${isNewHint ? ' animate-hint-reveal' : ''}`}
                   >
                     <div className="flex items-start gap-3">
                       <span className="flex-shrink-0 w-7 h-7 rounded-full bg-white/20 flex items-center justify-center text-sm font-bold font-baloo-2">

--- a/components/PageBackground.tsx
+++ b/components/PageBackground.tsx
@@ -5,33 +5,34 @@ import { CSSProperties } from 'react';
 /**
  * Ambient page background — the "Classic" annotated DICOM/PACS treatment from
  * the redesign prototype (radiordle-core.jsx `PageBackground`, `bg='annotated'`).
- * Soft aurora glows sit behind a subtle PACS overlay (corner metadata, R/L
- * orientation markers, couch curve, scale ruler), finished with film grain +
+ * A subtle PACS overlay (side rails by the R / L markers, corner metadata,
+ * couch curve, scale ruler) over a dark radial base, finished with film grain +
  * a center-focusing vignette.
  *
  * Purely decorative: pointer-events-none, aria-hidden. The whole thing renders
- * as a single static paint — the prototype's animated blur blobs were replaced
- * with static radial-gradient glows (no blur filters, no animation, no promoted
- * layers) so the background stays cheap and never re-rasterizes.
- * Sizing/position values that differed between the prototype's desktop and
- * mobile frames are expressed here as responsive Tailwind classes.
+ * as a single static paint — no blur filters, no animation, no promoted layers —
+ * so the background stays cheap and never re-rasterizes. Sizing/position values
+ * that differed between the prototype's desktop and mobile frames are expressed
+ * here as responsive Tailwind classes.
  */
 
 const MONO = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
 const RADBG =
-  'radial-gradient(120% 100% at 50% 34%, #0a1428 0%, #060b1a 62%, #03060f 100%)';
-const TICK = 'rgba(160,195,255,0.20)';
+  'radial-gradient(120% 100% at 50% 34%, #0f1c3a 0%, #0a1226 60%, #070c18 100%)';
 
-// Ambient aurora glows, baked into the background paint. These reproduce the
-// prototype's two heavily-blurred color blobs (blue top, teal lower-right) as
-// static radial gradients — same soft light field, but with no blur filter,
-// no animation, and no extra compositing layers, so the whole background
-// paints once and stays cheap. (Positions/alphas track the original blobs:
-// blue rgba(56,130,230) centered ~56%/30%, teal rgba(45,212,191) ~85%/73%.)
-const AURORA_A =
-  'radial-gradient(46% 42% at 56% 30%, rgba(56,130,230,0.20) 0%, rgba(56,130,230,0) 72%)';
-const AURORA_B =
-  'radial-gradient(42% 40% at 85% 73%, rgba(45,212,191,0.10) 0%, rgba(45,212,191,0) 72%)';
+// --- DICOM/PACS overlay brightness ---------------------------------------
+// Single knob for how strongly the annotation lines & text read against the
+// dark background (the vignette darkens the corners where most of them sit, so
+// they need a little lift). 1.0 = original prototype (dim). Presets to try:
+//   1.6 = medium · 2.1 = bright · 2.7 = brightest
+const DICOM_INTENSITY = 1.6;
+
+const lift = (alpha: number) => Math.min(alpha * DICOM_INTENSITY, 1);
+const META_COLOR = `rgba(170, 200, 255, ${lift(0.17)})`;
+const ORIENT_COLOR = `rgba(170, 200, 255, ${lift(0.22)})`;
+const RAIL_COLOR = `rgba(150, 185, 255, ${lift(0.1)})`;
+const CURVE_COLOR = `rgba(160, 195, 255, ${lift(0.22)})`;
+const TICK = `rgba(160, 195, 255, ${lift(0.2)})`;
 
 // Fine film grain — the detail that separates premium dark UIs from flat ones.
 function Grain({ opacity = 0.05 }: { opacity?: number }) {
@@ -52,7 +53,7 @@ function Grain({ opacity = 0.05 }: { opacity?: number }) {
 }
 
 // Center-focusing vignette so content stays legible over any texture.
-function Vignette({ strength = 0.66 }: { strength?: number }) {
+function Vignette({ strength = 0.5 }: { strength?: number }) {
   return (
     <div
       className="absolute inset-0"
@@ -70,7 +71,7 @@ export default function PageBackground() {
     fontFamily: MONO,
     lineHeight: 1.7,
     letterSpacing: '0.04em',
-    color: 'rgba(170,200,255,0.17)',
+    color: META_COLOR,
     whiteSpace: 'pre',
   };
   const orient: CSSProperties = {
@@ -78,7 +79,7 @@ export default function PageBackground() {
     fontSize: 15,
     fontWeight: 700,
     letterSpacing: '0.1em',
-    color: 'rgba(170,200,255,0.22)',
+    color: ORIENT_COLOR,
   };
   const ruler = Array.from({ length: 31 });
 
@@ -86,21 +87,21 @@ export default function PageBackground() {
     <div
       aria-hidden="true"
       className="absolute sm:fixed inset-0 overflow-hidden pointer-events-none"
-      style={{ background: `${AURORA_A}, ${AURORA_B}, ${RADBG}` }}
+      style={{ background: RADBG }}
     >
-      {/* Framing rule */}
-      <div
-        className="absolute"
-        style={{ inset: '5%', border: '1px solid rgba(150,185,255,0.10)', borderRadius: 3 }}
-      />
+      {/* Side rails flanking the R / L orientation markers */}
+      <div className="absolute top-[6%] bottom-[6%] w-px" style={{ left: '5%', background: RAIL_COLOR }} />
+      <div className="absolute top-[6%] bottom-[6%] w-px" style={{ right: '5%', background: RAIL_COLOR }} />
 
-      {/* Corner metadata — authentic PACS/DICOM fields */}
-      <div className="absolute text-[8.5px] sm:text-[11px]" style={{ top: '7%', left: '6%', ...meta }}>
+      {/* Corner metadata — authentic PACS/DICOM fields.
+          Top blocks use a fixed px offset so they always clear the glass navbar
+          (56px mobile / 84px desktop) instead of tucking under it. */}
+      <div className="absolute text-[8.5px] sm:text-[11px] top-[68px] sm:top-[96px]" style={{ left: '6%', ...meta }}>
         {'Im: 24/512\nSe: 3\nJPEG Lossy 20:1'}
       </div>
       <div
-        className="absolute text-[8.5px] sm:text-[11px] text-right"
-        style={{ top: '7%', right: '6%', ...meta }}
+        className="absolute text-[8.5px] sm:text-[11px] text-right top-[68px] sm:top-[96px]"
+        style={{ right: '6%', ...meta }}
       >
         {'Study ID: 100482\nCT ABDOMEN W/CONTRAST\nAXIAL 2.0MM SOFT TISSUE\nFlip H'}
       </div>
@@ -132,7 +133,7 @@ export default function PageBackground() {
         <path
           d="M0 44 Q400 6 800 44"
           fill="none"
-          stroke="rgba(160,195,255,0.22)"
+          stroke={CURVE_COLOR}
           strokeWidth="1.2"
           vectorEffect="non-scaling-stroke"
         />
@@ -157,7 +158,7 @@ export default function PageBackground() {
       ))}
 
       <Grain opacity={0.05} />
-      <Vignette strength={0.66} />
+      <Vignette strength={0.5} />
     </div>
   );
 }

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { BarChart3, Info, MessageCircle, Archive, Menu } from 'lucide-react';
+import GlassIconButton from './ui/GlassIconButton';
+import AccentButton from './ui/AccentButton';
+
+/**
+ * Glass top navigation bar (design: radiordle-screens.jsx `TopBar`).
+ *
+ * Renders two layouts side by side and lets CSS pick one — matching the app's
+ * existing dual-layout convention so SSR and the `:visible` e2e selectors keep
+ * working:
+ *   - Desktop (>= sm): Stats / About / Feedback on the left, centered wordmark,
+ *     Archives accent button on the right.
+ *   - Mobile (< sm): hamburger menu (About / Feedback / Stats), centered
+ *     wordmark, compact Archive accent button.
+ *
+ * The bar uses the shared glass tokens. Its `backdrop-filter` blur sits over the
+ * static (non-animated) page background, so it only re-rasterizes on scroll.
+ *
+ * Install (PWA) lives in a later, optional chunk and is intentionally omitted
+ * from the mobile menu for now.
+ */
+interface TopBarProps {
+  onStats: () => void;
+  onFeedback: () => void;
+}
+
+const barStyle = {
+  background: 'var(--glass-bg)',
+  backdropFilter: 'var(--glass-blur)',
+  WebkitBackdropFilter: 'var(--glass-blur)',
+  borderBottom: 'var(--glass-border)',
+  boxShadow: '0 4px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.16)',
+};
+
+const menuStyle = {
+  background: 'var(--glass-bg)',
+  backdropFilter: 'var(--glass-blur)',
+  WebkitBackdropFilter: 'var(--glass-blur)',
+  border: 'var(--glass-border)',
+  boxShadow: 'var(--glass-shadow)',
+  minWidth: 190,
+};
+
+function Wordmark({ iconSize, textClass }: { iconSize: number; textClass: string }) {
+  return (
+    <Link
+      href="/"
+      aria-label="Radiordle home"
+      className="flex items-center gap-1 drop-shadow-[0_4px_12px_rgba(0,0,0,0.5)]"
+    >
+      <span className="relative block flex-shrink-0" style={{ width: iconSize, height: iconSize }}>
+        <Image src="/radle_icon.svg" alt="Radiordle" fill className="object-contain" />
+      </span>
+      <span className={`font-baloo-2 font-extrabold text-white tracking-tight leading-none ${textClass}`}>
+        Radiordle
+      </span>
+    </Link>
+  );
+}
+
+export default function TopBar({ onStats, onFeedback }: TopBarProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <>
+      {/* ---- Desktop bar ---- */}
+      <div className="hidden sm:flex items-center px-8 h-[84px] flex-shrink-0 z-[60]" style={barStyle}>
+        <div className="flex-1 flex items-center justify-start gap-1">
+          <button
+            type="button"
+            onClick={onStats}
+            title="Stats"
+            aria-label="Stats"
+            className="flex items-center gap-2 h-11 px-3.5 rounded-xl text-base font-baloo-2 font-bold
+                       text-white/85 hover:text-white bg-white/[0.06] hover:bg-white/[0.13]
+                       border border-white/[0.12] transition-colors"
+          >
+            <BarChart3 size={20} />
+            <span>Stats</span>
+          </button>
+          <GlassIconButton label="About" href="/about">
+            <Info size={22} />
+          </GlassIconButton>
+          <GlassIconButton label="Feedback" onClick={onFeedback}>
+            <MessageCircle size={21} />
+          </GlassIconButton>
+        </div>
+
+        <Wordmark iconSize={46} textClass="text-[1.9rem]" />
+
+        <div className="flex-1 flex items-center justify-end">
+          <AccentButton icon={<Archive size={19} />} label="Archives" href="/archive" />
+        </div>
+      </div>
+
+      {/* ---- Mobile bar ---- */}
+      <div className="relative flex sm:hidden flex-col flex-shrink-0 z-[60]">
+        <div className="flex items-center justify-between px-3 h-14" style={barStyle}>
+          <GlassIconButton label="Menu" size={40} onClick={() => setMenuOpen((m) => !m)}>
+            <Menu size={22} />
+          </GlassIconButton>
+          <Wordmark iconSize={34} textClass="text-[1.45rem]" />
+          <AccentButton icon={<Archive size={17} />} label="Archive" compact href="/archive" />
+        </div>
+
+        {menuOpen && (
+          <>
+            {/* Click-away layer */}
+            <div className="fixed inset-0 z-[55]" onClick={() => setMenuOpen(false)} aria-hidden="true" />
+            <div className="absolute left-3 top-[60px] z-[61] rounded-xl overflow-hidden" style={menuStyle}>
+              <Link
+                href="/about"
+                onClick={() => setMenuOpen(false)}
+                className="flex items-center gap-3 w-full px-4 py-3 text-left text-white font-baloo-2 font-semibold
+                           border-b border-white/10 transition-colors hover:bg-white/10"
+              >
+                <span className="text-white/80">
+                  <Info size={18} />
+                </span>
+                About
+              </Link>
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onFeedback();
+                }}
+                className="flex items-center gap-3 w-full px-4 py-3 text-left text-white font-baloo-2 font-semibold
+                           border-b border-white/10 transition-colors hover:bg-white/10"
+              >
+                <span className="text-white/80">
+                  <MessageCircle size={18} />
+                </span>
+                Feedback
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onStats();
+                }}
+                className="flex items-center gap-3 w-full px-4 py-3 text-left text-white font-baloo-2 font-semibold
+                           transition-colors hover:bg-white/10"
+              >
+                <span className="text-white/80">
+                  <BarChart3 size={18} />
+                </span>
+                Stats
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/ui/AccentButton.tsx
+++ b/components/ui/AccentButton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+/**
+ * AccentButton — the amber call-to-action used for Archives and other primary
+ * actions (design foundation: radiordle-core.jsx `AccentButton`).
+ *
+ * Amber gradient + soft glow, bold black display text. Renders as a Next
+ * `<Link>` when `href` is given, otherwise a `<button>`. The gradient is wired
+ * to the `--color-accent*` tokens so it stays in sync with the palette.
+ */
+interface AccentButtonProps {
+  icon?: ReactNode;
+  label?: string;
+  /** Smaller, tighter sizing for compact/mobile placements. */
+  compact?: boolean;
+  /** When set, renders as a navigation link instead of a button. */
+  href?: string;
+  onClick?: () => void;
+  /** Falls back to `label` for `title` / `aria-label`. */
+  title?: string;
+  className?: string;
+}
+
+const ACCENT_STYLE = {
+  background: 'linear-gradient(to bottom, var(--color-accent-light), var(--color-accent))',
+  boxShadow: '0 4px 14px rgba(245, 158, 11, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.4)',
+};
+
+export default function AccentButton({
+  icon,
+  label,
+  compact = false,
+  href,
+  onClick,
+  title,
+  className = '',
+}: AccentButtonProps) {
+  const sizeCls = compact ? 'gap-1.5 px-3.5 h-9 text-sm' : 'gap-2 px-4 h-11 text-base';
+  const cls =
+    'inline-flex items-center justify-center font-baloo-2 font-bold text-black ' +
+    `rounded-xl transition-transform active:scale-95 ${sizeCls} ${className}`.trim();
+  const accessibleTitle = title ?? label;
+
+  const inner = (
+    <>
+      {icon}
+      {label && <span>{label}</span>}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} title={accessibleTitle} className={cls} style={ACCENT_STYLE}>
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={onClick} title={accessibleTitle} className={cls} style={ACCENT_STYLE}>
+      {inner}
+    </button>
+  );
+}

--- a/components/ui/GlassIconButton.tsx
+++ b/components/ui/GlassIconButton.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+/**
+ * GlassIconButton — a square, icon-only control used across the navbar and
+ * modals (design foundation: radiordle-core.jsx `GlassIconButton`).
+ *
+ * Transparent by default, a soft white wash on hover. Renders as a Next
+ * `<Link>` when `href` is given, otherwise a `<button>`. Colors/hover come
+ * from Tailwind utilities (no per-frame JS state), keeping it a static paint.
+ */
+interface GlassIconButtonProps {
+  children: ReactNode;
+  /** Used for both `title` and `aria-label` (icon-only, so a label is required). */
+  label: string;
+  /** Square size in px. */
+  size?: number;
+  /** When set, renders as a navigation link instead of a button. */
+  href?: string;
+  onClick?: () => void;
+  className?: string;
+}
+
+const BASE =
+  'flex items-center justify-center rounded-xl transition-colors ' +
+  'text-white/80 hover:text-white hover:bg-white/10';
+
+export default function GlassIconButton({
+  children,
+  label,
+  size = 44,
+  href,
+  onClick,
+  className = '',
+}: GlassIconButtonProps) {
+  const cls = `${BASE} ${className}`.trim();
+  const style = { width: size, height: size };
+
+  if (href) {
+    return (
+      <Link href={href} title={label} aria-label={label} className={cls} style={style}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={onClick} title={label} aria-label={label} className={cls} style={style}>
+      {children}
+    </button>
+  );
+}

--- a/design-reference/REDESIGN_PLAN.md
+++ b/design-reference/REDESIGN_PLAN.md
@@ -58,24 +58,24 @@ main  (live / Vercel)  ───────────────────
 ## Chunks (do in order — later ones build on the foundation)
 
 ### Foundation (do first — everything depends on these)
-- [ ] **01 · Design tokens & fonts** — port `C`/`GLASS` values + Baloo 2 / Inter fonts + the
+- [x] **01 · Design tokens & fonts** — port `C`/`GLASS` values + Baloo 2 / Inter fonts + the
   `@keyframes` (toastIn, fadeIn, modalEnter, hintReveal, bgDriftA/B) into `globals.css` and
   `layout.tsx`. Low risk, little visual change on its own; unblocks the rest.
-- [ ] **02 · Animated background** — new `PageBackground.tsx` (aurora blobs + grain + vignette;
+- [x] **02 · Animated background** — new `PageBackground.tsx` (aurora blobs + grain + vignette;
   start with the `annotated` "Classic" DICOM variant which the mockup ships). High visual impact,
   self-contained. Wire into `GamePage.tsx` behind the content.
-- [ ] **03 · Glass primitives** — shared `GlassIconButton` + `AccentButton` (amber gradient).
+- [x] **03 · Glass primitives** — shared `GlassIconButton` + `AccentButton` (amber gradient).
   Used by the navbar and modals; build once, reuse.
 
 ### Core game screen
-- [ ] **04 · Top navbar** — glass bar, centered wordmark, Stats/About/Feedback on the left,
+- [x] **04 · Top navbar** — glass bar, centered wordmark, Stats/About/Feedback on the left,
   Archives accent button right; mobile hamburger menu with Install/About/Feedback/Stats.
-- [ ] **05 · X-ray card** — 16:9 black card, result-colored border (green/yellow/red ring),
+- [x] **05 · X-ray card** — 16:9 black card, result-colored border (green/yellow/red ring),
   zoom affordance bottom-right.
-- [ ] **06 · Hint cards** — colored-by-next-guess cards, numbered badge, reveal animation.
-- [ ] **07 · Guess bar + autocomplete** — glass input with "Guess N/5" label, amber Submit,
+- [x] **06 · Hint cards** — colored-by-next-guess cards, numbered badge, reveal animation.
+- [x] **07 · Guess bar + autocomplete** — glass input with "Guess N/5" label, amber Submit,
   dropdown styling, disabled "previously selected" rows, inline error state.
-- [ ] **08 · Toasts** — correct/partial/incorrect/copied toast styling + timing.
+- [x] **08 · Toasts** — correct/partial/incorrect/copied toast styling + timing.
 
 ### Modals
 - [ ] **09 · Results modal** — biggest one: header w/ result tiles + gradient answer, collapsible

--- a/e2e/tests/mobile-responsive.spec.ts
+++ b/e2e/tests/mobile-responsive.spec.ts
@@ -124,10 +124,11 @@ test.describe('Mobile Responsiveness', () => {
   test('should show stats/archive buttons on mobile', async ({ page }) => {
     await waitForGameLoad(page);
 
-    // Stats button should be visible
-    await expect(page.getByText('Stats').first()).toBeVisible();
+    // Archive accent button is visible directly in the mobile top bar
+    await expect(page.getByRole('link', { name: /archive/i }).first()).toBeVisible();
 
-    // Archives button should be visible
-    await expect(page.getByText('Archives').first()).toBeVisible();
+    // Stats lives inside the mobile hamburger menu — open it, then it's visible
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await expect(page.getByText('Stats').first()).toBeVisible();
   });
 });


### PR DESCRIPTION
Ports redesign **chunks 03–08** onto `feature/ui-redesign`, plus the review tweaks from the working session. Presentation only — the Supabase data flow and `lib/` logic are untouched.

## Chunks
- **03 · Glass primitives** — new `components/ui/GlassIconButton` + `AccentButton` (polymorphic Link/button, amber gradient wired to `--color-accent*`). Build once, reused by the navbar.
- **04 · Top navbar** — new `components/TopBar`: glass bar; desktop = Stats chip + About/Feedback icons, centered wordmark, Archives accent button; mobile = hamburger menu (About/Feedback/Stats) + compact Archive. Replaces the old header in `GamePage`.
- **05 · X-ray card** — 2px result-colored border (neutral → success/warning/error) + static drop shadow, replacing the ring/glow.
- **06 · Hint cards** — already matched the prototype; `transition-all` → `transition-colors` only.
- **07 · Guess bar + autocomplete** — `DiagnosisAutocomplete` redesigned: integrated `Guess N/5` mono label, dark-glass dropdown (dimmed previously-guessed rows), themed **white** input pill, amber Submit, red error state.
- **08 · Toasts** — already on-design; no change.

## Review tweaks
- **Background:** removed the two ambient orbs; DICOM annotation brightness is now a single knob (set to 1.6); square frame → two side rails by R/L; top metadata offset so it clears the navbar; lighter base gradient + softer vignette.
- **Perf:** dropped `backdrop-filter` on the fixed input pill (biggest mobile scroll win) and reduced the shared glass blur `22px → 14px` — both cut per-frame backdrop re-sampling during scroll, keeping the glass look.

## Constraints honored
- **Data safety:** no code touches localStorage / stats / game state.
- **Perf:** static background paint; border/hover feedback is color-only; blur minimized.
- **Responsive:** dual-layout (render both, CSS-toggle) preserved, so SSR and the `:visible` e2e selectors keep working.

## Tests
- `pnpm lint` 0 errors · `pnpm tsc` clean · `pnpm test` **159/159**.
- Preserved every e2e/unit selector; updated **3 assertions** to match restyled classes and the new mobile menu (autocomplete selected-item class ×2, mobile nav ×1).
- Full Playwright suite (`pnpm e2e`) not run per the per-chunk gate — worth a pass before the final `feature/ui-redesign → main` PR.

## Notes
- **Install** is intentionally omitted from the mobile menu (its screen is the later optional chunk 15).
- Checklist boxes 01–08 ticked in `design-reference/REDESIGN_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)